### PR TITLE
include 'version.h' instead of 'Version.h'

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ configure_file(
         "${PROJECT_BINARY_DIR}/version.h"
 )
 
-add_definitions("-include ${PROJECT_BINARY_DIR}/Version.h")
+add_definitions("-include ${PROJECT_BINARY_DIR}/version.h")
 include_directories(${PROJECT_BINARY_DIR})
 
 # use highest optimization level and optimize for size

--- a/src/xplane/ImGuiWindow.cpp
+++ b/src/xplane/ImGuiWindow.cpp
@@ -36,7 +36,7 @@
 // XMidiCtrl
 #include "ImGuiWindow.h"
 #include "logger.h"
-#include "Version.h"
+#include "version.h"
 
 namespace xmidictrl {
 


### PR DESCRIPTION
On Windows the difference in case doesn't matter,
but on Systems with case-sensitive filesystems this makes
compilation fail. Fix it by changing it to all-lowercase.

Signed-off-by: Sven Schnelle <svens@stackframe.org>