### PR TITLE
Fix build problem in Visual Studio - name clash with preproc macro.

### DIFF
--- a/src/profile/device.cpp
+++ b/src/profile/device.cpp
@@ -24,6 +24,11 @@
 #include "plugin.h"
 #include "conversions.h"
 
+// Make sure min is not defined as a macro otherwise time_point::min() will not compile
+#if defined(_MSC_VER) && defined(min)
+#undef min
+#endif
+
 namespace xmidictrl {
 
 //---------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Fixes a minor problem building the latest version using Visual Studio