### PR TITLE
detect click on pads which measure pressure

### DIFF
--- a/docs/inbound_mapping_command.md
+++ b/docs/inbound_mapping_command.md
@@ -16,8 +16,8 @@ returns to the map screen.
 
 | Parameter  | Description                             |
 |------------|-----------------------------------------|
-| data_2_on  | Data 2 for button pressed (Default 127) |
-| data-2_off | Data 2 for button released (Default 0)  |
+| data_2_on  | Data 2 when button value equal or higher (Default 127) |
+| data_2_off | Data 2 when button value equal or less (Default 0)  |
 
 ## Examples
 

--- a/src/device/map_in/map_in_cmd.cpp
+++ b/src/device/map_in/map_in_cmd.cpp
@@ -140,10 +140,10 @@ std::unique_ptr<map_result> map_in_cmd::execute(map_param* in_param)
 	if (!check_sublayer(param_in->sl_value()))
 		return result;
 
-	if (param_in->msg().data_2() == m_data_2_on) {
+	if (param_in->msg().data_2() >= m_data_2_on) {
 		param_in->msg().log().debug(fmt::format(" --> Begin execution of command '{}'", m_command));
 		env().cmd().begin(param_in->msg().log(), m_command);
-	} else if (param_in->msg().data_2() == m_data_2_off) {
+	} else if (param_in->msg().data_2() <= m_data_2_off) {
 		param_in->msg().log().debug(fmt::format(" --> End execution of command '{}'", m_command));
 		env().cmd().end(param_in->msg().log(), m_command);
 	} else {


### PR DESCRIPTION
Some Midi controllers (like Akai LPD8) measure pad pressing pressure in the range from 1 to 127.
It needed to click pretty harshly to reach 127 value, and it is mostly impossible to get the same value between two clicks.
This PR allows the setting of a minimal pressure threshold to detect the click.
 